### PR TITLE
Add AI chat widget with persistent messages and styles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Portfolio from "./components/portfolio/Portfolio";
 import Testimonials from "./components/testimonials/Testimonials";
 import Contact from "./components/contact/Contact";
 import Footer from "./components/footer/Footer";
+import Chat from "./components/chat/Chat";
 import NotificationContainer from "react-notifications/lib/NotificationContainer";
 import "react-notifications/lib/notifications.css";
 
@@ -23,6 +24,7 @@ const App = () => {
       <Testimonials />
       <Contact />
       <Footer />
+      <Chat />
       <NotificationContainer />
     </div>
   );

--- a/src/components/chat/Chat.jsx
+++ b/src/components/chat/Chat.jsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import axios from "axios";
+import { BiMessageSquareDetail, BiX, BiSend } from "react-icons/bi";
+import "./chat.css";
+
+const STORAGE_KEY = "portfolio_chat_messages";
+
+const Chat = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const messagesEndRef = useRef(null);
+
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return;
+      }
+
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        setMessages(parsed);
+      }
+    } catch (storageError) {
+      console.log(storageError);
+    }
+  }, []);
+
+  useEffect(() => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+  }, [messages]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isLoading, isOpen]);
+
+  const canSend = useMemo(() => {
+    return input.trim() && !isLoading;
+  }, [input, isLoading]);
+
+  const sendMessage = async () => {
+    const trimmed = input.trim();
+
+    if (!trimmed || isLoading) {
+      return;
+    }
+
+    const userMessage = {
+      id: Date.now(),
+      role: "user",
+      text: trimmed,
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+    setError("");
+    setIsLoading(true);
+
+    try {
+      const { data } = await axios.post("/chat", {
+        message: trimmed,
+      });
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now() + 1,
+          role: "assistant",
+          text: data?.response || "I could not generate a response just now.",
+        },
+      ]);
+    } catch (requestError) {
+      console.log(requestError);
+      setError("Unable to reach chat right now. Please try again.");
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now() + 1,
+          role: "assistant",
+          text: "Sorry, something went wrong while getting a response.",
+        },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await sendMessage();
+  };
+
+  return (
+    <div className="chat">
+      <button
+        className="chat__trigger"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-label={isOpen ? "Close chat" : "Open chat"}
+        title={isOpen ? "Close chat" : "Open chat"}
+      >
+        {isOpen ? <BiX /> : <BiMessageSquareDetail />}
+      </button>
+
+      <div className={`chat__panel ${isOpen ? "chat__panel-open" : ""}`}>
+        <div className="chat__header">
+          <h4>AI Assistant</h4>
+          <span className="chat__status">Online</span>
+        </div>
+
+        <div className="chat__messages">
+          {messages.length === 0 && (
+            <div className="chat__empty">
+              Ask anything about this portfolio, projects, or skills.
+            </div>
+          )}
+
+          {messages.map((message) => (
+            <div
+              key={message.id}
+              className={`chat__message chat__message-${message.role}`}
+            >
+              {message.text}
+            </div>
+          ))}
+
+          {isLoading && (
+            <div className="chat__message chat__message-assistant chat__typing">
+              <span />
+              <span />
+              <span />
+            </div>
+          )}
+
+          <div ref={messagesEndRef} />
+        </div>
+
+        {error && <p className="chat__error">{error}</p>}
+
+        <form className="chat__input-row" onSubmit={handleSubmit}>
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type your message..."
+            aria-label="Message"
+          />
+          <button type="submit" disabled={!canSend} aria-label="Send message">
+            <BiSend />
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Chat;

--- a/src/components/chat/chat.css
+++ b/src/components/chat/chat.css
@@ -1,0 +1,206 @@
+.chat {
+  position: fixed;
+  right: 2rem;
+  bottom: 2rem;
+  z-index: 10;
+}
+
+.chat__trigger {
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+  cursor: pointer;
+  color: var(--color-bg);
+  background: var(--color-primary);
+  box-shadow: 0 0.8rem 1.8rem rgba(0, 0, 0, 0.35);
+  transition: var(--transition);
+}
+
+.chat__trigger:hover {
+  filter: brightness(1.08);
+  transform: translateY(-2px);
+}
+
+.chat__panel {
+  width: min(24rem, 90vw);
+  height: min(30rem, 70vh);
+  margin-bottom: 0.9rem;
+  border-radius: 1.1rem;
+  background: var(--color-bg-variant);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(12px) scale(0.98);
+  pointer-events: none;
+  transition: var(--transition);
+}
+
+.chat__panel-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.chat__header {
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.chat__header h4 {
+  font-size: 0.95rem;
+}
+
+.chat__status {
+  font-size: 0.72rem;
+  color: var(--color-light);
+}
+
+.chat__messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chat__empty {
+  font-size: 0.85rem;
+  color: var(--color-light);
+}
+
+.chat__message {
+  max-width: 85%;
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.8rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.chat__message-user {
+  align-self: flex-end;
+  background: var(--color-primary);
+  color: var(--color-bg);
+  border-bottom-right-radius: 0.3rem;
+}
+
+.chat__message-assistant {
+  align-self: flex-start;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-white);
+  border-bottom-left-radius: 0.3rem;
+}
+
+.chat__typing {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.chat__typing span {
+  width: 0.35rem;
+  height: 0.35rem;
+  border-radius: 50%;
+  background: var(--color-white);
+  opacity: 0.45;
+  animation: chat-typing 1s infinite ease-in-out;
+}
+
+.chat__typing span:nth-child(2) {
+  animation-delay: 0.12s;
+}
+
+.chat__typing span:nth-child(3) {
+  animation-delay: 0.24s;
+}
+
+@keyframes chat-typing {
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.35;
+  }
+  40% {
+    transform: translateY(-3px);
+    opacity: 1;
+  }
+}
+
+.chat__error {
+  margin: 0 1rem;
+  font-size: 0.76rem;
+  color: #ff8f8f;
+}
+
+.chat__input-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem;
+}
+
+.chat__input-row input {
+  width: 100%;
+  background: rgba(0, 0, 0, 0.26);
+  color: var(--color-white);
+  border: 1px solid transparent;
+  border-radius: 0.6rem;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.82rem;
+}
+
+.chat__input-row input:focus {
+  border-color: var(--color-primary);
+}
+
+.chat__input-row button {
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 0.6rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  color: var(--color-bg);
+  background: var(--color-primary);
+  transition: var(--transition);
+}
+
+.chat__input-row button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media screen and (max-width: 1024px) {
+  .chat {
+    right: 1.4rem;
+    bottom: 1.4rem;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .chat {
+    right: 0.8rem;
+    bottom: 0.9rem;
+  }
+
+  .chat__panel {
+    height: min(27rem, 68vh);
+    margin-bottom: 0.7rem;
+  }
+
+  .chat__trigger {
+    width: 3rem;
+    height: 3rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Add an embedded AI chat assistant to the portfolio to let visitors ask questions about projects, skills, or the site in real time.
- Keep conversations across the session by persisting messages to `sessionStorage` under `STORAGE_KEY` so users can continue context while the tab is open.
- Provide an unobtrusive, accessible floating widget with clear open/close affordance and typing/loading/error feedback.

### Description
- Add new `Chat` component at `src/components/chat/Chat.jsx` that manages message state, input, loading and error states, scrolls to the latest message, and submits queries via `axios.post('/chat')`.
- Persist and restore messages using `sessionStorage` and the `STORAGE_KEY` constant, and render assistant/user messages with a typing indicator while awaiting responses.
- Add styles for the widget in `src/components/chat/chat.css`, including the trigger button, panel open/close transition, message bubbles, typing animation, responsive layout, and error styling.
- Integrate the chat into the main app by importing `Chat` in `src/App.jsx` and rendering `<Chat />`; use icons from `react-icons/bi` and include ARIA attributes for accessibility.

### Testing
- No automated tests were added or run for this change.
- The change does not modify existing test files or test configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c77d46d22c8321a5476f8072aeeed8)