### PR TITLE
Upgrade chat into portfolio Query Console (suggestions, pipeline loading, markdown & sources)

### DIFF
--- a/src/components/chat/Chat.jsx
+++ b/src/components/chat/Chat.jsx
@@ -1,9 +1,115 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import axios from "axios";
-import { BiMessageSquareDetail, BiX, BiSend } from "react-icons/bi";
+import { BiMessageSquareDetail, BiX, BiSend, BiChevronDown } from "react-icons/bi";
 import "./chat.css";
 
 const STORAGE_KEY = "portfolio_chat_messages";
+const SUGGESTIONS = [
+  "Top backend skills",
+  "Projects in AI",
+  "Compare skills 2023–2025",
+  "Show recent full-stack projects",
+];
+const PIPELINE_STEPS = [
+  "Understanding your query...",
+  "Searching portfolio...",
+  "Preparing response...",
+];
+
+const escapeHtml = (value = "") =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const markdownToHtml = (markdown = "") => {
+  let html = escapeHtml(markdown);
+
+  html = html.replace(/```([\s\S]*?)```/g, (_, code) => `<pre><code>${code.trim()}</code></pre>`);
+  html = html.replace(/^### (.*)$/gm, "<h3>$1</h3>");
+  html = html.replace(/^## (.*)$/gm, "<h2>$1</h2>");
+  html = html.replace(/^# (.*)$/gm, "<h1>$1</h1>");
+
+  html = html.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/\*(.*?)\*/g, "<em>$1</em>");
+  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+  html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>');
+
+  html = html.replace(/(?:^|\n)- (.*?)(?=\n[^- ]|$)/gs, (block) => {
+    const items = block
+      .trim()
+      .split("\n")
+      .filter((line) => line.startsWith("- "))
+      .map((line) => `<li>${line.slice(2)}</li>`)
+      .join("");
+    return `<ul>${items}</ul>`;
+  });
+
+  html = html
+    .split(/\n{2,}/)
+    .map((chunk) => {
+      const trimmed = chunk.trim();
+      if (!trimmed) {
+        return "";
+      }
+
+      if (/^<(h1|h2|h3|ul|pre)/.test(trimmed)) {
+        return trimmed;
+      }
+
+      return `<p>${trimmed.replace(/\n/g, "<br />")}</p>`;
+    })
+    .join("");
+
+  return html;
+};
+
+const normalizeSources = (sources) => {
+  if (!Array.isArray(sources)) {
+    return [];
+  }
+
+  return sources
+    .map((source, index) => {
+      if (!source || typeof source !== "object") {
+        return null;
+      }
+
+      const tags = Array.isArray(source.tags)
+        ? source.tags.filter((tag) => typeof tag === "string" && tag.trim())
+        : [];
+
+      return {
+        id: source.id || `${source.title || "source"}-${index}`,
+        title: source.title || source.name || "Portfolio source",
+        description:
+          source.description ||
+          source.summary ||
+          source.excerpt ||
+          "Relevant context from the portfolio.",
+        tags,
+      };
+    })
+    .filter(Boolean);
+};
+
+const renderMessageText = (data) => {
+  if (!data) {
+    return "I could not generate a response just now.";
+  }
+
+  if (typeof data.response === "string" && data.response.trim()) {
+    return data.response;
+  }
+
+  if (typeof data.answer === "string" && data.answer.trim()) {
+    return data.answer;
+  }
+
+  return "I could not generate a response just now.";
+};
 
 const Chat = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -11,6 +117,8 @@ const Chat = () => {
   const [messages, setMessages] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
+  const [loadingStepIndex, setLoadingStepIndex] = useState(0);
+  const [expandedSources, setExpandedSources] = useState({});
   const messagesEndRef = useRef(null);
 
   useEffect(() => {
@@ -41,12 +149,34 @@ const Chat = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading, isOpen]);
 
+  useEffect(() => {
+    if (!isLoading) {
+      setLoadingStepIndex(0);
+      return undefined;
+    }
+
+    const interval = window.setInterval(() => {
+      setLoadingStepIndex((prev) => (prev + 1) % PIPELINE_STEPS.length);
+    }, 1100);
+
+    return () => window.clearInterval(interval);
+  }, [isLoading]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    document.body.classList.add("chat-console-open");
+    return () => document.body.classList.remove("chat-console-open");
+  }, [isOpen]);
+
   const canSend = useMemo(() => {
     return input.trim() && !isLoading;
   }, [input, isLoading]);
 
-  const sendMessage = async () => {
-    const trimmed = input.trim();
+  const sendMessage = async (prefilledMessage) => {
+    const trimmed = (prefilledMessage ?? input).trim();
 
     if (!trimmed || isLoading) {
       return;
@@ -73,18 +203,20 @@ const Chat = () => {
         {
           id: Date.now() + 1,
           role: "assistant",
-          text: data?.response || "I could not generate a response just now.",
+          text: renderMessageText(data),
+          sources: normalizeSources(data?.sources),
         },
       ]);
     } catch (requestError) {
       console.log(requestError);
-      setError("Unable to reach chat right now. Please try again.");
+      setError("Unable to reach query console right now. Please try again.");
       setMessages((prev) => [
         ...prev,
         {
           id: Date.now() + 1,
           role: "assistant",
-          text: "Sorry, something went wrong while getting a response.",
+          text: "Sorry, something went wrong while preparing your response.",
+          sources: [],
         },
       ]);
     } finally {
@@ -97,44 +229,114 @@ const Chat = () => {
     await sendMessage();
   };
 
+  const handleSuggestionClick = async (suggestion) => {
+    setInput(suggestion);
+    await sendMessage(suggestion);
+  };
+
+  const toggleSource = (messageId) => {
+    setExpandedSources((prev) => ({
+      ...prev,
+      [messageId]: !prev[messageId],
+    }));
+  };
+
   return (
     <div className="chat">
       <button
         className="chat__trigger"
         onClick={() => setIsOpen((prev) => !prev)}
-        aria-label={isOpen ? "Close chat" : "Open chat"}
-        title={isOpen ? "Close chat" : "Open chat"}
+        aria-label={isOpen ? "Close query console" : "Open query console"}
+        title={isOpen ? "Close query console" : "Open query console"}
       >
         {isOpen ? <BiX /> : <BiMessageSquareDetail />}
       </button>
 
-      <div className={`chat__panel ${isOpen ? "chat__panel-open" : ""}`}>
+      {isOpen && <button className="chat__backdrop" onClick={() => setIsOpen(false)} aria-label="Close query console" />}
+
+      <section className={`chat__panel ${isOpen ? "chat__panel-open" : ""}`} aria-hidden={!isOpen}>
         <div className="chat__header">
-          <h4>AI Assistant</h4>
-          <span className="chat__status">Online</span>
+          <div>
+            <h4>Portfolio Query Console</h4>
+            <p>Explore skills, projects, and experience with guided queries.</p>
+          </div>
+          <button className="chat__close" onClick={() => setIsOpen(false)} aria-label="Close query console">
+            <BiX />
+          </button>
         </div>
 
         <div className="chat__messages">
           {messages.length === 0 && (
             <div className="chat__empty">
-              Ask anything about this portfolio, projects, or skills.
+              Ask targeted questions to explore this portfolio quickly.
             </div>
           )}
 
           {messages.map((message) => (
-            <div
+            <article
               key={message.id}
               className={`chat__message chat__message-${message.role}`}
             >
-              {message.text}
-            </div>
+              <div className="chat__message-content">
+                {message.role === "assistant" ? (
+                  <div
+                    dangerouslySetInnerHTML={{
+                      __html: markdownToHtml(message.text),
+                    }}
+                  />
+                ) : (
+                  message.text
+                )}
+              </div>
+
+              {message.role === "assistant" && message.sources?.length > 0 && (
+                <div className="chat__sources">
+                  <button
+                    className="chat__sources-toggle"
+                    type="button"
+                    onClick={() => toggleSource(message.id)}
+                    aria-expanded={Boolean(expandedSources[message.id])}
+                  >
+                    View sources
+                    <BiChevronDown
+                      className={expandedSources[message.id] ? "chat__sources-open" : ""}
+                    />
+                  </button>
+
+                  {expandedSources[message.id] && (
+                    <div className="chat__sources-list">
+                      {message.sources.map((source) => (
+                        <div key={source.id} className="chat__source-item">
+                          <h5>{source.title}</h5>
+                          {source.tags.length > 0 && (
+                            <div className="chat__source-tags">
+                              {source.tags.map((tag) => (
+                                <span key={`${source.id}-${tag}`}>{tag}</span>
+                              ))}
+                            </div>
+                          )}
+                          <p>{source.description}</p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </article>
           ))}
 
           {isLoading && (
-            <div className="chat__message chat__message-assistant chat__typing">
-              <span />
-              <span />
-              <span />
+            <div className="chat__loading" role="status" aria-live="polite">
+              <div className="chat__loading-steps">
+                {PIPELINE_STEPS.map((step, index) => (
+                  <p
+                    key={step}
+                    className={index === loadingStepIndex ? "chat__loading-step-active" : ""}
+                  >
+                    {step}
+                  </p>
+                ))}
+              </div>
             </div>
           )}
 
@@ -143,19 +345,35 @@ const Chat = () => {
 
         {error && <p className="chat__error">{error}</p>}
 
-        <form className="chat__input-row" onSubmit={handleSubmit}>
-          <input
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Type your message..."
-            aria-label="Message"
-          />
-          <button type="submit" disabled={!canSend} aria-label="Send message">
-            <BiSend />
-          </button>
-        </form>
-      </div>
+        <div className="chat__composer">
+          <div className="chat__chips" aria-label="Suggested queries">
+            {SUGGESTIONS.map((suggestion) => (
+              <button
+                type="button"
+                key={suggestion}
+                className="chat__chip"
+                onClick={() => handleSuggestionClick(suggestion)}
+                disabled={isLoading}
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+
+          <form className="chat__input-row" onSubmit={handleSubmit}>
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Ask about skills, projects, experience..."
+              aria-label="Query"
+            />
+            <button type="submit" disabled={!canSend} aria-label="Send query">
+              <BiSend />
+            </button>
+          </form>
+        </div>
+      </section>
     </div>
   );
 };

--- a/src/components/chat/chat.css
+++ b/src/components/chat/chat.css
@@ -2,7 +2,7 @@
   position: fixed;
   right: 2rem;
   bottom: 2rem;
-  z-index: 10;
+  z-index: 14;
 }
 
 .chat__trigger {
@@ -17,6 +17,8 @@
   background: var(--color-primary);
   box-shadow: 0 0.8rem 1.8rem rgba(0, 0, 0, 0.35);
   transition: var(--transition);
+  position: relative;
+  z-index: 16;
 }
 
 .chat__trigger:hover {
@@ -24,11 +26,21 @@
   transform: translateY(-2px);
 }
 
+.chat__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.62);
+  border: none;
+  z-index: 14;
+}
+
 .chat__panel {
-  width: min(24rem, 90vw);
-  height: min(30rem, 70vh);
-  margin-bottom: 0.9rem;
-  border-radius: 1.1rem;
+  position: fixed;
+  right: 1rem;
+  bottom: 6rem;
+  width: min(70rem, calc(100vw - 2rem));
+  height: min(48rem, calc(100vh - 7.5rem));
+  border-radius: 1.25rem;
   background: var(--color-bg-variant);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.45);
@@ -39,6 +51,7 @@
   transform: translateY(12px) scale(0.98);
   pointer-events: none;
   transition: var(--transition);
+  z-index: 15;
 }
 
 .chat__panel-open {
@@ -48,42 +61,93 @@
 }
 
 .chat__header {
-  padding: 0.9rem 1rem;
+  padding: 1rem 1.25rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  gap: 0.75rem;
+  align-items: flex-start;
 }
 
 .chat__header h4 {
-  font-size: 0.95rem;
+  font-size: 1rem;
 }
 
-.chat__status {
-  font-size: 0.72rem;
+.chat__header p {
+  margin-top: 0.2rem;
+  font-size: 0.82rem;
   color: var(--color-light);
+}
+
+.chat__close {
+  width: 2.3rem;
+  height: 2.3rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-white);
+  display: grid;
+  place-items: center;
 }
 
 .chat__messages {
   flex: 1;
   overflow-y: auto;
-  padding: 1rem;
+  padding: 1rem 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .chat__empty {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--color-light);
 }
 
 .chat__message {
-  max-width: 85%;
-  padding: 0.6rem 0.8rem;
+  max-width: min(85%, 55rem);
+  padding: 0.7rem 0.9rem;
   border-radius: 0.8rem;
-  font-size: 0.85rem;
-  line-height: 1.4;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.chat__message-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.chat__message-content p,
+.chat__message-content ul,
+.chat__message-content ol,
+.chat__message-content pre,
+.chat__message-content h1,
+.chat__message-content h2,
+.chat__message-content h3,
+.chat__message-content h4 {
+  margin: 0;
+}
+
+.chat__message-content ul,
+.chat__message-content ol {
+  padding-left: 1.2rem;
+}
+
+.chat__message-content a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.chat__message-content pre {
+  overflow-x: auto;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 0.55rem;
+  padding: 0.7rem;
+  font-size: 0.78rem;
+}
+
+.chat__message-content code {
+  font-family: "Roboto Mono", monospace;
 }
 
 .chat__message-user {
@@ -100,54 +164,136 @@
   border-bottom-left-radius: 0.3rem;
 }
 
-.chat__typing {
+.chat__sources {
+  margin-top: 0.55rem;
+}
+
+.chat__sources-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: var(--color-primary);
 }
 
-.chat__typing span {
-  width: 0.35rem;
-  height: 0.35rem;
-  border-radius: 50%;
-  background: var(--color-white);
-  opacity: 0.45;
-  animation: chat-typing 1s infinite ease-in-out;
+.chat__sources-toggle svg {
+  transition: transform 0.2s ease;
 }
 
-.chat__typing span:nth-child(2) {
-  animation-delay: 0.12s;
+.chat__sources-open {
+  transform: rotate(180deg);
 }
 
-.chat__typing span:nth-child(3) {
-  animation-delay: 0.24s;
+.chat__sources-list {
+  margin-top: 0.5rem;
+  display: grid;
+  gap: 0.5rem;
 }
 
-@keyframes chat-typing {
-  0%,
-  80%,
-  100% {
-    transform: translateY(0);
-    opacity: 0.35;
-  }
-  40% {
-    transform: translateY(-3px);
-    opacity: 1;
-  }
+.chat__source-item {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.6rem;
+  padding: 0.55rem;
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.chat__source-item h5 {
+  font-size: 0.82rem;
+  margin-bottom: 0.25rem;
+}
+
+.chat__source-item p {
+  color: var(--color-light);
+  font-size: 0.76rem;
+}
+
+.chat__source-tags {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.35rem;
+}
+
+.chat__source-tags span {
+  font-size: 0.7rem;
+  border: 1px solid rgba(77, 181, 255, 0.45);
+  color: var(--color-primary);
+  border-radius: 99px;
+  padding: 0.12rem 0.5rem;
+}
+
+.chat__loading {
+  align-self: flex-start;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  min-width: 16rem;
+}
+
+.chat__loading-steps {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.chat__loading-steps p {
+  font-size: 0.77rem;
+  color: var(--color-light);
+  transition: var(--transition);
+}
+
+.chat__loading-step-active {
+  color: var(--color-primary) !important;
+  transform: translateX(3px);
 }
 
 .chat__error {
-  margin: 0 1rem;
-  font-size: 0.76rem;
+  margin: 0 1.25rem;
+  font-size: 0.78rem;
   color: #ff8f8f;
 }
 
-.chat__input-row {
+.chat__composer {
   border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.75rem 1rem 1rem;
+  background: linear-gradient(
+    180deg,
+    rgba(24, 31, 46, 0.82) 0%,
+    rgba(24, 31, 46, 0.98) 100%
+  );
+}
+
+.chat__chips {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.6rem;
+  margin-bottom: 0.55rem;
+  scrollbar-width: thin;
+}
+
+.chat__chip {
+  border: 1px solid rgba(77, 181, 255, 0.45);
+  border-radius: 999px;
+  white-space: nowrap;
+  padding: 0.32rem 0.7rem;
+  color: var(--color-primary);
+  font-size: 0.77rem;
+  transition: var(--transition);
+}
+
+.chat__chip:hover:enabled {
+  background: rgba(77, 181, 255, 0.15);
+}
+
+.chat__chip:disabled {
+  opacity: 0.6;
+}
+
+.chat__input-row {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.7rem;
 }
 
 .chat__input-row input {
@@ -155,9 +301,9 @@
   background: rgba(0, 0, 0, 0.26);
   color: var(--color-white);
   border: 1px solid transparent;
-  border-radius: 0.6rem;
-  padding: 0.65rem 0.75rem;
-  font-size: 0.82rem;
+  border-radius: 0.7rem;
+  padding: 0.68rem 0.75rem;
+  font-size: 0.84rem;
 }
 
 .chat__input-row input:focus {
@@ -165,9 +311,9 @@
 }
 
 .chat__input-row button {
-  width: 2.2rem;
-  height: 2.2rem;
-  border-radius: 0.6rem;
+  width: 2.3rem;
+  height: 2.3rem;
+  border-radius: 0.62rem;
   display: grid;
   place-items: center;
   cursor: pointer;
@@ -183,20 +329,45 @@
 
 @media screen and (max-width: 1024px) {
   .chat {
-    right: 1.4rem;
-    bottom: 1.4rem;
+    right: 1.1rem;
+    bottom: 1.1rem;
+  }
+
+  .chat__panel {
+    right: 0.75rem;
+    width: calc(100vw - 1.5rem);
+    height: calc(100vh - 6.5rem);
   }
 }
 
 @media screen and (max-width: 600px) {
   .chat {
     right: 0.8rem;
-    bottom: 0.9rem;
+    bottom: 0.8rem;
   }
 
   .chat__panel {
-    height: min(27rem, 68vh);
-    margin-bottom: 0.7rem;
+    right: 0;
+    bottom: 0;
+    width: 100vw;
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+    border: none;
+  }
+
+  .chat__messages {
+    padding: 0.9rem;
+  }
+
+  .chat__message {
+    max-width: 95%;
+  }
+
+  .chat__composer {
+    position: sticky;
+    bottom: 0;
+    padding: 0.75rem 0.8rem calc(0.9rem + env(safe-area-inset-bottom));
   }
 
   .chat__trigger {


### PR DESCRIPTION
### Motivation
- Turn the casual chatbot into a purpose-driven Query Console for exploring skills, projects, and experience while reusing the existing chat flow and `/chat` API contract.  
- Improve discoverability and speed of answers with guided prompts, staged loading states, and progressive disclosure of sources.  
- Support richer assistant output (Markdown-like formatting, code blocks, links) with minimal dependency changes so the feature works in restricted environments.

### Description
- Extended the existing `Chat` component (`src/components/chat/Chat.jsx`) to add guided suggestion chips, pipeline loading steps, markdown-to-HTML rendering (`markdownToHtml`), and a `normalizeSources` function to safely present source title/tags/description without exposing raw metadata.  
- Preserved session persistence and `/chat` integration while updating `sendMessage` to attach `sources` and to render assistant text via the new renderer.  
- Reworked layout and styles (`src/components/chat/chat.css`) to a workspace-style panel with backdrop, larger responsive panel, full-screen mobile behavior, sticky composer, chip styling, source accordion, and animated pipeline-step active state.  
- Implemented a lightweight in-component Markdown rendering fallback (headings, bold/italic, lists, code blocks, links) after an attempt to add `react-markdown` was blocked by registry access.

### Testing
- Ran `npm run build` in the environment and it failed with `react-scripts: not found`, so a full build verification could not be completed.  
- Attempted `npm install react-markdown@^9.0.1` and the install was blocked by the registry with `403 Forbidden`, so external package validation was not possible.  
- Unit/UI tests were not present; manual runtime verification and visual QA should be performed after installing dependencies and running the app locally (the implementation preserves the `/chat` endpoint and session storage for easier local validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c798825b0083218c73403a202e16fb)