### PR TITLE
Refine query console with fullscreen glass UI and richer sources

### DIFF
--- a/src/components/chat/Chat.jsx
+++ b/src/components/chat/Chat.jsx
@@ -107,6 +107,7 @@ const normalizeSources = (sources) => {
         id: document.id || `${document.title || "source"}-${index}`,
         title: document.title || "Portfolio source",
         description:
+          document.content_full ||
           document.summary_for_embedding ||
           document.summary ||
           "Relevant context from the portfolio.",
@@ -144,7 +145,9 @@ const Chat = () => {
   const [error, setError] = useState("");
   const [loadingStepIndex, setLoadingStepIndex] = useState(0);
   const [expandedSources, setExpandedSources] = useState({});
+  const [expandedSourceContent, setExpandedSourceContent] = useState({});
   const messagesEndRef = useRef(null);
+  const SOURCE_PREVIEW_LIMIT = 220;
 
   useEffect(() => {
     try {
@@ -278,16 +281,25 @@ const Chat = () => {
     }));
   };
 
+  const toggleSourceContent = (sourceKey) => {
+    setExpandedSourceContent((prev) => ({
+      ...prev,
+      [sourceKey]: !prev[sourceKey],
+    }));
+  };
+
   return (
     <div className="chat">
-      <button
-        className={`chat__trigger ${!isOpen ? "chat__trigger-attention" : "chat__trigger-open"}`}
-        onClick={() => setIsOpen((prev) => !prev)}
-        aria-label={isOpen ? "Close Moonmind" : "Open Moonmind"}
-        title={isOpen ? "Close Moonmind" : "Open Moonmind"}
-      >
-        {isOpen ? <BiX /> : <BiBrain />}
-      </button>
+      {!isOpen && (
+        <button
+          className={`chat__trigger ${!isOpen ? "chat__trigger-attention" : "chat__trigger-open"}`}
+          onClick={() => setIsOpen((prev) => !prev)}
+          aria-label="Open Moonmind"
+          title="Open Moonmind"
+        >
+          <BiBrain />
+        </button>
+      )}
 
       {isOpen && (
         <button
@@ -367,7 +379,25 @@ const Chat = () => {
                               ))}
                             </div>
                           )}
-                          <p>{source.description}</p>
+                          <p>
+                            {source.description.length > SOURCE_PREVIEW_LIMIT &&
+                            !expandedSourceContent[`${message.id}-${source.id}`]
+                              ? `${source.description.slice(0, SOURCE_PREVIEW_LIMIT)}...`
+                              : source.description}
+                          </p>
+                          {source.description.length > SOURCE_PREVIEW_LIMIT && (
+                            <button
+                              className="chat__source-expand"
+                              type="button"
+                              onClick={() =>
+                                toggleSourceContent(`${message.id}-${source.id}`)
+                              }
+                            >
+                              {expandedSourceContent[`${message.id}-${source.id}`]
+                                ? "Show less"
+                                : "Show more"}
+                            </button>
+                          )}
                         </div>
                       ))}
                     </div>
@@ -417,16 +447,18 @@ const Chat = () => {
           </div>
 
           <form className="chat__input-row" onSubmit={handleSubmit}>
-            <input
-              type="text"
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="Ask about skills, projects, experience..."
-              aria-label="Query"
-            />
-            <button type="submit" disabled={!canSend} aria-label="Send query">
-              <BiSend />
-            </button>
+            <div className="chat__input-wrap">
+              <input
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="Ask about skills, projects, experience..."
+                aria-label="Query"
+              />
+              <button type="submit" disabled={!canSend} aria-label="Send query">
+                <BiSend />
+              </button>
+            </div>
           </form>
         </div>
       </section>

--- a/src/components/chat/chat.css
+++ b/src/components/chat/chat.css
@@ -110,14 +110,16 @@
 
 .chat__panel {
     position: fixed;
-    right: 1rem;
-    bottom: 6rem;
-    width: min(70rem, calc(100vw - 2rem));
-    height: min(48rem, calc(100vh - 7.5rem));
-    border-radius: 1.25rem;
-    background: var(--color-bg-variant);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.45);
+    inset: 0;
+    width: 100vw;
+    height: 100dvh;
+    border-radius: 0;
+    background: radial-gradient(circle at top right, rgba(26, 64, 83, 0.42), rgba(7, 11, 22, 0.94) 45%),
+        rgba(8, 15, 30, 0.88);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(120, 238, 255, 0.16);
+    box-shadow: inset 0 0 2rem rgba(0, 0, 0, 0.35);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -135,8 +137,8 @@
 }
 
 .chat__header {
-    padding: 1rem 1.25rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 1rem 1.4rem;
+    border-bottom: 1px solid rgba(120, 238, 255, 0.14);
     display: flex;
     justify-content: space-between;
     gap: 0.75rem;
@@ -167,7 +169,7 @@
 .chat__messages {
     flex: 1;
     overflow-y: auto;
-    padding: 1rem 1.25rem;
+    padding: 1rem 1.4rem;
     display: flex;
     flex-direction: column;
     gap: 0.85rem;
@@ -234,7 +236,8 @@
 
 .chat__message-assistant {
     align-self: flex-start;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(122, 202, 255, 0.08);
+    border: 1px solid rgba(122, 202, 255, 0.18);
     color: var(--color-white);
     border-bottom-left-radius: 0.3rem;
 }
@@ -249,6 +252,17 @@
     gap: 0.35rem;
     font-size: 0.78rem;
     color: var(--color-primary);
+    border: 1px solid rgba(77, 181, 255, 0.35);
+    border-radius: 999px;
+    padding: 0.24rem 0.56rem;
+    background: rgba(77, 181, 255, 0.1);
+    box-shadow: 0 0 0 transparent;
+    transition: var(--transition);
+}
+
+.chat__sources-toggle:hover {
+    background: rgba(77, 181, 255, 0.2);
+    box-shadow: 0 0 0.6rem rgba(77, 181, 255, 0.3);
 }
 
 .chat__sources-toggle svg {
@@ -280,6 +294,12 @@
 .chat__source-item p {
     color: var(--color-light);
     font-size: 0.76rem;
+}
+
+.chat__source-expand {
+    margin-top: 0.35rem;
+    font-size: 0.72rem;
+    color: var(--color-primary);
 }
 
 .chat__source-tags {
@@ -329,12 +349,12 @@
 }
 
 .chat__composer {
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-top: 1px solid rgba(120, 238, 255, 0.14);
     padding: 0.75rem 1rem 1rem;
     background: linear-gradient(
         180deg,
-        rgba(24, 31, 46, 0.82) 0%,
-        rgba(24, 31, 46, 0.98) 100%
+        rgba(10, 26, 39, 0.82) 0%,
+        rgba(10, 26, 39, 0.96) 100%
     );
 }
 
@@ -366,18 +386,20 @@
 }
 
 .chat__input-row {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    display: block;
+}
+
+.chat__input-wrap {
+    position: relative;
 }
 
 .chat__input-row input {
     width: 100%;
-    background: rgba(0, 0, 0, 0.26);
+    background: rgba(5, 12, 25, 0.72);
     color: var(--color-white);
-    border: 1px solid transparent;
-    border-radius: 0.7rem;
-    padding: 0.68rem 0.75rem;
+    border: 1px solid rgba(77, 181, 255, 0.3);
+    border-radius: 0.9rem;
+    padding: 0.72rem 3rem 0.72rem 0.85rem;
     font-size: 0.84rem;
 }
 
@@ -395,6 +417,10 @@
     color: var(--color-bg);
     background: var(--color-primary);
     transition: var(--transition);
+    position: absolute;
+    right: 0.3rem;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .chat__input-row button:disabled {
@@ -409,9 +435,8 @@
     }
 
     .chat__panel {
-        right: 0.75rem;
-        width: calc(100vw - 1.5rem);
-        height: calc(100vh - 6.5rem);
+        width: 100vw;
+        height: 100dvh;
     }
 }
 
@@ -422,8 +447,6 @@
     }
 
     .chat__panel {
-        right: 0;
-        bottom: 0;
         width: 100vw;
         height: 100dvh;
         max-height: 100dvh;


### PR DESCRIPTION
### Motivation
- Improve the Moonmind chat console's UX and visual polish without changing core logic or adding new components. 
- Make the chat modal occupy the full viewport, tighten the input/send layout, surface richer source content, and add small interactive affordances (truncation/expansion, hover glow) while preserving existing open/close behavior. 
- Keep all changes scoped to the chat component and its styles to avoid global regressions. 

### Description
- Prefer `content_full` when normalizing document sources in `normalizeSources`, falling back to existing summary fields. 
- Add per-source truncation and expansion using a `SOURCE_PREVIEW_LIMIT` and `expandedSourceContent` state with `Show more` / `Show less` toggles. 
- Render the launcher only when the panel is closed (hiding the bottom floating close icon while open) and preserve close via the header close button and backdrop. 
- Move the send button inside the input container by adding a `chat__input-wrap` wrapper and minimal DOM updates to `Chat.jsx`, and position the send button via `chat.css` for alignment and responsiveness. 
- Convert the chat panel to a full-screen glassmorphism style by updating `.chat__panel` (inset layout, blur, dark blue-green gradients, subtle borders/shadows) and refine assistant bubble and `View sources` hover/glow styles; all style changes are scoped to `src/components/chat/chat.css`. 
- Changes are intentionally incremental and localized to `src/components/chat/Chat.jsx` and `src/components/chat/chat.css`. 

### Testing
- Ran the production build with `npm run build`, which completed successfully and produced the optimized build. 
- The build emitted pre-existing ESLint warnings unrelated to the chat changes, and no new build errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94eea44748321b74bad3577ebb436)